### PR TITLE
Seperated comm

### DIFF
--- a/main/config_switcher.h
+++ b/main/config_switcher.h
@@ -137,11 +137,10 @@ esp_err_t configUpdateVB(void *param, command_type_t type, uint8_t vb);
 esp_err_t task_configswitcher_getAT(char* output, void* cfg);
 
 
-/** @brief Trigger a config update
+/** @brief Request config update
  * 
- * This method is simply sending an "__UPDATE" command to the
- * config_switcher queue to trigger an update by re-loading the
- * currentConfig.
+ * This method is requesting a config update.
+ * If a request is already pending, this method does nothing.
  * 
  * @see config_switcher
  * @see currentConfig

--- a/main/doxygen.h
+++ b/main/doxygen.h
@@ -73,6 +73,7 @@
  * @todo Implement buzzer in remaining task_* functions (strongsip/puff exit)
  * @todo Test Neopixels on FABI & FLipMouse
  * @todo Test AT MA (macros).
+ * @todo Delete slot 0 cannot mean delete all anymore!
  * 
  * @todo Implement long press for virtual buttons (new VBs).
 */

--- a/main/flipmouse_fabi_esp32_kbdmouse_main.c
+++ b/main/flipmouse_fabi_esp32_kbdmouse_main.c
@@ -55,13 +55,9 @@
 EventGroupHandle_t virtualButtonsOut[NUMBER_VIRTUALBUTTONS];
 EventGroupHandle_t virtualButtonsIn[NUMBER_VIRTUALBUTTONS];
 EventGroupHandle_t connectionRoutingStatus;
-QueueHandle_t keyboard_usb_press;
-QueueHandle_t keyboard_usb_release;
 QueueHandle_t keyboard_ble_press;
 QueueHandle_t keyboard_ble_release;
-QueueHandle_t mouse_movement_usb;
 QueueHandle_t mouse_movement_ble;
-QueueHandle_t joystick_movement_usb;
 QueueHandle_t joystick_movement_ble;
 QueueHandle_t config_switcher;
 QueueHandle_t hid_usb;
@@ -138,13 +134,9 @@ void app_main()
             virtualButtonsOut[i] = xEventGroupCreate();
         }
         //queues
-        keyboard_usb_press = xQueueCreate(10,sizeof(uint16_t));
-        keyboard_usb_release = xQueueCreate(10,sizeof(uint16_t));
         keyboard_ble_press = xQueueCreate(10,sizeof(uint16_t));
         keyboard_ble_release = xQueueCreate(10,sizeof(uint16_t));
-        mouse_movement_usb = xQueueCreate(10,sizeof(mouse_command_t));
         mouse_movement_ble = xQueueCreate(10,sizeof(mouse_command_t));
-        joystick_movement_usb = xQueueCreate(10,sizeof(joystick_command_t)); //TBD: right size?
         joystick_movement_ble = xQueueCreate(10,sizeof(joystick_command_t)); //TBD: right size?
         config_switcher = xQueueCreate(5,sizeof(char)*SLOTNAME_LENGTH);
         hid_ble = xQueueCreate(10,sizeof(usb_command_t));

--- a/main/flipmouse_fabi_esp32_kbdmouse_main.c
+++ b/main/flipmouse_fabi_esp32_kbdmouse_main.c
@@ -64,6 +64,8 @@ QueueHandle_t mouse_movement_ble;
 QueueHandle_t joystick_movement_usb;
 QueueHandle_t joystick_movement_ble;
 QueueHandle_t config_switcher;
+QueueHandle_t hid_usb;
+QueueHandle_t hid_ble;
 
 radio_status_t radio = UNINITIALIZED;
 
@@ -122,7 +124,7 @@ void switch_radio(void)
 void app_main()
 {
     //set log level to info
-    esp_log_level_set("*",ESP_LOG_INFO);
+    //esp_log_level_set("*",ESP_LOG_INFO);
     
     //enter critical section & suspend all tasks for initialising
     vTaskSuspendAll();
@@ -145,6 +147,9 @@ void app_main()
         joystick_movement_usb = xQueueCreate(10,sizeof(joystick_command_t)); //TBD: right size?
         joystick_movement_ble = xQueueCreate(10,sizeof(joystick_command_t)); //TBD: right size?
         config_switcher = xQueueCreate(5,sizeof(char)*SLOTNAME_LENGTH);
+        hid_ble = xQueueCreate(10,sizeof(usb_command_t));
+        hid_usb = xQueueCreate(10,sizeof(usb_command_t));
+        
     //exit critical section & resume all tasks for initialising
     xTaskResumeAll();
 

--- a/main/function_tasks/common.h
+++ b/main/function_tasks/common.h
@@ -209,6 +209,11 @@ extern QueueHandle_t joystick_movement_usb;
 /** queue which receives joystick commands, triggered via BLE */
 extern QueueHandle_t joystick_movement_ble;
 
+/** @brief Queue for sending HID commands to USB */
+extern QueueHandle_t hid_usb;
+/** @brief Queue for sending HID commands to BLE */
+extern QueueHandle_t hid_ble;
+
 
 /** @brief Possible states of the radio (wifi & BLE) */
 typedef enum {UNINITIALIZED,WIFI,BLE,BLE_PAIRING} radio_status_t;
@@ -514,6 +519,11 @@ typedef struct mouse_command {
   int8_t wheel;
   uint8_t buttons;
 } mouse_command_t;
+
+typedef struct usb_command {
+  uint8_t len;
+  uint8_t data[16];
+} usb_command_t;
 
 /**++++ TODO: move to task_joystick.h ++++*/
 typedef struct joystick_command {

--- a/main/function_tasks/common.h
+++ b/main/function_tasks/common.h
@@ -65,7 +65,7 @@
 /** ID String to be printed on "AT ID" command.
  * @todo Change this back to new version, when GUI is compatible */
 //#define IDSTRING "FLipMouse V3.0\r\n"
-#define IDSTRING "Flipmouse v2.5\n"
+#define IDSTRING "Flipmouse v2.5"
 //#define IDSTRING "FABI v3.0\n"
 
 /** @brief Determine used device. Either FABI or FLipMouse.
@@ -378,8 +378,8 @@ extern QueueHandle_t config_switcher;
 #define DEBOUNCER_TASK_PRIORITY  (tskIDLE_PRIORITY + 1)
 /** All BLE tasks in hal_ble.c. */
 #define HAL_BLE_TASK_PRIORITY_BASE  (tskIDLE_PRIORITY + 2)
-#define HAL_CONFIG_TASK_PRIORITY  (tskIDLE_PRIORITY + 2)
-#define TASK_COMMANDS_PRIORITY  (tskIDLE_PRIORITY + 2)
+#define HAL_CONFIG_TASK_PRIORITY  (tskIDLE_PRIORITY + 1)
+#define TASK_COMMANDS_PRIORITY  (tskIDLE_PRIORITY + 3)
 
 /*++++ MAIN CONFIG STRUCT ++++*/
 

--- a/main/function_tasks/common.h
+++ b/main/function_tasks/common.h
@@ -190,22 +190,12 @@ extern EventGroupHandle_t connectionRoutingStatus;
  * byte of the input text
  **/
 
-/** queue which receives USB keycodes which needs to be pressed */
-extern QueueHandle_t keyboard_usb_press;
-/** queue which receives USB keycodes which needs to be released */
-extern QueueHandle_t keyboard_usb_release;
 /** queue which receives ble keycodes which needs to be pressed */
 extern QueueHandle_t keyboard_ble_press;
 /** queue which receives ble keycodes which needs to be released */
 extern QueueHandle_t keyboard_ble_release;
-
-
-/** queue which receives mouse commands, triggered via USB */
-extern QueueHandle_t mouse_movement_usb;
 /** queue which receives mouse commands, triggered via BLE */
 extern QueueHandle_t mouse_movement_ble;
-/** queue which receives joystick commands, triggered via USB */
-extern QueueHandle_t joystick_movement_usb;
 /** queue which receives joystick commands, triggered via BLE */
 extern QueueHandle_t joystick_movement_ble;
 

--- a/main/function_tasks/task_debouncer.c
+++ b/main/function_tasks/task_debouncer.c
@@ -158,7 +158,7 @@ void sendButtonLearn(uint8_t vb, uint8_t press, generalConfig_t *cfg)
   {
     if(press) sprintf(str,"%d PRESS",vb);
     else sprintf(str,"%d RELEASE",vb);
-    halSerialSendUSBSerial(HAL_SERIAL_TX_TO_CDC,str,strnlen(str,13),20);
+    halSerialSendUSBSerial(str,strnlen(str,13),20);
   }
   return;
 }

--- a/main/function_tasks/task_infrared.c
+++ b/main/function_tasks/task_infrared.c
@@ -229,7 +229,7 @@ esp_err_t infrared_record(char* cmdName, uint8_t outputtoserial)
         {
           sprintf(&output[i*8],"%08X\r\n",cfg->buffer[i].val);
         }
-        halSerialSendUSBSerial(HAL_SERIAL_TX_TO_CDC,output,strnlen(output,8*cfg->count + 4),10);
+        halSerialSendUSBSerial(output,strnlen(output,8*cfg->count + 4),10);
       }
       break;
     case IR_OVERFLOW:

--- a/main/function_tasks/task_infrared.c
+++ b/main/function_tasks/task_infrared.c
@@ -292,7 +292,7 @@ esp_err_t task_infrared_getAT(char* output, void* cfg)
   taskInfraredConfig_t *conf = (taskInfraredConfig_t *)cfg;
   if(conf == NULL) return ESP_FAIL;
   //very easy in this case: just extract the slot name.
-  sprintf(output,"AT IP %s\r\n",conf->cmdName);
+  sprintf(output,"AT IP %s",conf->cmdName);
   
   return ESP_OK;
 }

--- a/main/function_tasks/task_kbd.c
+++ b/main/function_tasks/task_kbd.c
@@ -125,8 +125,6 @@ esp_err_t task_keyboard_getAT(char* output, void* cfg)
       output[i+5] = (char)conf->keycodes_text[TASK_KEYBOARD_PARAMETERLENGTH-i];
     }
   }
-  
-  strcat(output,"\r\n");
   return ESP_OK;
 }
 

--- a/main/function_tasks/task_macros.c
+++ b/main/function_tasks/task_macros.c
@@ -198,7 +198,7 @@ esp_err_t task_macro_getAT(char* output, void* cfg)
   taskMacrosConfig_t *conf = (taskMacrosConfig_t *)cfg;
   if(conf == NULL) return ESP_FAIL;
   //very easy in this case: just extract the macro list of AT cmds.
-  sprintf(output,"AT MA %s\r\n",conf->macro);
+  sprintf(output,"AT MA %s",conf->macro);
   
   return ESP_OK;
 }

--- a/main/function_tasks/task_mouse.c
+++ b/main/function_tasks/task_mouse.c
@@ -98,13 +98,19 @@ void task_mouse(taskMouseConfig_t *param)
   //ticks between task timeouts
   const TickType_t xTicksToWait = 2000 / portTICK_PERIOD_MS;
   //mouse command which is sent.
-  mouse_command_t press;
-  mouse_command_t release;
-  mouse_command_t empty;
+  usb_command_t press;
+  usb_command_t release;
+  usb_command_t empty;
   //empty them
-  memset(&press,0,sizeof(mouse_command_t));
-  memset(&release,0,sizeof(mouse_command_t));
-  memset(&empty,0,sizeof(mouse_command_t));
+  memset(&press,0,sizeof(usb_command_t));
+  memset(&release,0,sizeof(usb_command_t));
+  memset(&empty,0,sizeof(usb_command_t));
+  empty.len = 5;
+  empty.data[0] = 'M';
+  press.len = 5;
+  press.data[0] = 'M';
+  release.len = 5;
+  release.data[0] = 'M';
 
   //button mask to be used by this task
   uint8_t buttonmask = 0;
@@ -148,7 +154,7 @@ void task_mouse(taskMouseConfig_t *param)
     case WHEEL: 
     {
       buttonmask = 0;
-      press.wheel = (int8_t) param->actionvalue;
+      press.data[4] = (int8_t) param->actionvalue;
       param->actionparam = M_UNUSED;
       break;
     }
@@ -156,7 +162,7 @@ void task_mouse(taskMouseConfig_t *param)
     case X:
     {
       buttonmask = 0;
-      press.x = (int8_t) param->actionvalue;
+      press.data[3] = (int8_t) param->actionvalue;
       param->actionparam = M_UNUSED;
       break;
     }
@@ -164,7 +170,7 @@ void task_mouse(taskMouseConfig_t *param)
     case Y:
     {
       buttonmask = 0;
-      press.y = (int8_t) param->actionvalue;
+      press.data[2] = (int8_t) param->actionvalue;
       param->actionparam = M_UNUSED;
       break;
     }
@@ -181,12 +187,12 @@ void task_mouse(taskMouseConfig_t *param)
   switch(param->actionparam)
   {
     case M_CLICK:
-      press.buttons = buttonmask;
+      press.data[1] = buttonmask;
       autorelease = 1;
       break;
     case M_HOLD:
-      press.buttons = buttonmask;
-      release.buttons = 0;
+      press.data[1] = buttonmask;
+      release.data[1] = 0;
       if(param->virtualButton == VB_SINGLESHOT)
       {
         userelease = 0;
@@ -195,12 +201,12 @@ void task_mouse(taskMouseConfig_t *param)
       }
       break;
     case M_DOUBLE:
-      press.buttons = buttonmask;
+      press.data[1] = buttonmask;
       clickcount = 2;
       autorelease = 1;
       break;
     case M_RELEASE:
-      press.buttons = 0;
+      press.data[1] = 0;
     case M_UNUSED: break;
     default:
       ESP_LOGE(LOG_TAG,"unkown mouse action param %d, exiting",param->actionparam);
@@ -222,17 +228,19 @@ void task_mouse(taskMouseConfig_t *param)
         {
           //if press is set
           if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_USB) 
-          { xQueueSend(mouse_movement_usb,&press,TIMEOUT); }
-          if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_BLE) 
-          { xQueueSend(mouse_movement_ble,&press,TIMEOUT); }
+          { xQueueSend(hid_usb,&press,TIMEOUT); }
+          //TODO: activate if BLE uses same structure
+          /*if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_BLE) 
+          { xQueueSend(mouse_movement_ble,&press,TIMEOUT); }*/
           
           //send second command if set
           if(autorelease)
           {
             if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_USB) 
-            { xQueueSend(mouse_movement_usb,&empty,TIMEOUT); }
-            if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_BLE) 
-            { xQueueSend(mouse_movement_ble,&empty,TIMEOUT); }
+            { xQueueSend(hid_usb,&empty,TIMEOUT); }
+            //TODO: activate if BLE uses same structure
+            /*if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_BLE) 
+            { xQueueSend(mouse_movement_ble,&empty,TIMEOUT); }*/
           }
         }
       }
@@ -243,9 +251,10 @@ void task_mouse(taskMouseConfig_t *param)
         if(userelease)
         {
           if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_USB)
-          { xQueueSend(mouse_movement_usb,&release,TIMEOUT); }
-          if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_BLE) 
-          { xQueueSend(mouse_movement_ble,&release,TIMEOUT); }
+          { xQueueSend(hid_usb,&release,TIMEOUT); }
+          //TODO: activate if BLE uses same structure
+          //if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_BLE) 
+          //{ xQueueSend(mouse_movement_ble,&release,TIMEOUT); }
         }
       }
       

--- a/main/function_tasks/task_mouse.c
+++ b/main/function_tasks/task_mouse.c
@@ -276,12 +276,12 @@ esp_err_t task_mouse_getAT(char* output, void* cfg)
     case WHEEL:
       if(conf->actionvalue > 0)
       {
-        sprintf(output,"AT WU\r\n"); break;
+        sprintf(output,"AT WU"); break;
       } else {
-        sprintf(output,"AT WD\r\n"); break;
+        sprintf(output,"AT WD"); break;
       }
-    case X: sprintf(output,"AT MX %d\r\n",conf->actionvalue); break;
-    case Y: sprintf(output,"AT MY %d\r\n",conf->actionvalue); break;
+    case X: sprintf(output,"AT MX %d",conf->actionvalue); break;
+    case Y: sprintf(output,"AT MY %d",conf->actionvalue); break;
     default: return ESP_FAIL;
   }
   
@@ -290,16 +290,16 @@ esp_err_t task_mouse_getAT(char* output, void* cfg)
     switch(conf->actionparam)
     {
       case M_CLICK:
-        sprintf(output,"AT C%c\r\n",button);
+        sprintf(output,"AT C%c",button);
         break;
       case M_HOLD:
-        sprintf(output,"AT P%c\r\n",button);
+        sprintf(output,"AT P%c",button);
         break;
       case M_RELEASE:
-        sprintf(output,"AT R%c\r\n",button);
+        sprintf(output,"AT R%c",button);
         break;
       case M_DOUBLE:
-        sprintf(output,"AT CD\r\n");
+        sprintf(output,"AT CD");
         break;
       case M_UNUSED:
         ESP_LOGW(LOG_TAG,"Unused actionparam, but type requires...");

--- a/main/function_tasks/task_webgui.c
+++ b/main/function_tasks/task_webgui.c
@@ -63,6 +63,9 @@ const static char *base_path = "/spiflash";
 /** @brief Currently used wifi password */
 static char wifipw[64];
 
+/** @brief Wear levelling handle */
+static wl_handle_t fat_handle = WL_INVALID_HANDLE;
+
 /** @brief Static HTTP HTML header */
 const static char http_html_hdr[] = "HTTP/1.1 200 OK\nContent-type: text/html\n\n";
 /** @brief Static HTTP 404 header */
@@ -537,6 +540,13 @@ esp_err_t taskWebGUIInit(void)
     
   /*++++ initialize capitive portal dns server ++++*/
 	//captdnsInit();
+  
+  /*++++ initialize storage, having a definetly opened partition ++++*/
+  uint32_t tid;
+  if(halStorageStartTransaction(&tid,20,"webgui") != ESP_OK) {
+    ESP_LOGE(LOG_TAG,"Cannot initialize storage");
+  }
+  halStorageFinishTransaction(tid);
   
   /*++++ initialize auto-off timer */
   //init timer with given number of minutes. No reload, no timer id.

--- a/main/hal/hal_adc.c
+++ b/main/hal/hal_adc.c
@@ -219,7 +219,7 @@ void halAdcReportRaw(uint32_t up, uint32_t down, uint32_t left, uint32_t right, 
         {
             char data[40];
             sprintf(data,"VALUES:%d,%d,%d,%d,%d,%d,%d",pressure,up,down,left,right,x,y);
-            halSerialSendUSBSerial(HAL_SERIAL_TX_TO_CDC,data, strnlen(data,40), 10);
+            halSerialSendUSBSerial(data, strnlen(data,40), 10);
         }
         prescaler++;
     }
@@ -533,7 +533,11 @@ void halAdcTaskMouse(void * pvParameters)
     float moveVal, accumXpos = 0, accumYpos = 0;
     //todo: use a define for the delay here... (currently used: value from vTaskDelay())
     float accelFactor= 20 / 100000000.0f;
-    mouse_command_t command;
+    usb_command_t command;
+    command.len = 5;
+    command.data[0] = 'M';  //send a mouse report
+    command.data[1] = 0xFF; //for handling in hal_serial: having sticky buttons with 0xFF
+    
     TickType_t xLastWakeTime;
     //set adc data reference for timer
     vTimerSetTimerID(adcStrongTimerHandle,&D);
@@ -595,15 +599,15 @@ void halAdcTaskMouse(void * pvParameters)
             //if at least one value is != 0, send to mouse.
             if ((tempX != 0) || (tempY != 0))
             {
-                command.x = tempX;
-                command.y = tempY;
+                command.data[2] = tempX;
+                command.data[3] = tempY;
                 accumXpos -= tempX;
                 accumYpos -= tempY;
                 
                 //post values to mouse queue (USB and/or BLE)
                 if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_USB)
                 {
-                    xQueueSend(mouse_movement_usb,&command,0);
+                    xQueueSend(hid_usb,&command,0);
                 }
                 
                 if(xEventGroupGetBits(connectionRoutingStatus) & DATATO_BLE)
@@ -1139,8 +1143,7 @@ esp_err_t halAdcInit(adc_config_t* params)
             return ESP_FAIL;
         }
     }
-    if(joystick_movement_usb == NULL || joystick_movement_ble == NULL || \
-        mouse_movement_ble == NULL || mouse_movement_usb == NULL)
+    if(joystick_movement_ble == NULL || mouse_movement_ble == NULL || hid_usb == NULL)
     {
         ESP_LOGE("hal_adc","queue uninitialized, exiting");
         return ESP_FAIL;

--- a/main/hal/hal_io.c
+++ b/main/hal/hal_io.c
@@ -382,7 +382,7 @@ void halIOLEDTask(void * param)
   uint32_t fade = 0;
   #endif
   #ifdef DEVICE_FABI
-  char cmd[5];
+  usb_command_t cmd;
   #endif
   generalConfig_t *cfg = configGetCurrent();
   
@@ -412,14 +412,13 @@ void halIOLEDTask(void * param)
       #ifdef DEVICE_FABI
       
       //'L' + <red> + <green> + <blue> + '\0'
-      cmd[0] = 'L';
-      cmd[1] = recv & 0x000000FF;
-      cmd[2] = ((recv & 0x0000FF00) >> 8);
-      cmd[3] = ((recv & 0x00FF0000) >> 16);
-      cmd[4] = '\0';
-      //send to USB chip (use HID channel, otherwise it would be sent to USB host)
-      halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,cmd,strnlen(cmd,6)+1,20);
-      
+      cmd.data[0] = 'L';
+      cmd.data[1] = recv & 0x000000FF;
+      cmd.data[2] = ((recv & 0x0000FF00) >> 8);
+      cmd.data[3] = ((recv & 0x00FF0000) >> 16);
+      cmd.len = 4;
+      //send to USB chip
+      xQueueSend(hid_usb,&cmd,10);
       #endif
       
       //FLipMouse with RGB LEDs

--- a/main/hal/hal_io.h
+++ b/main/hal/hal_io.h
@@ -208,7 +208,9 @@
  * The IR code in FLipMouse/FABI uses RMT channels 0 and 4, therefor
  * both channels (RX&TX) could use up to 4 blocks for saving waveforms.
  * If there is need for a RMT channel for different purposes (e.g. Neopixel output), reduce
- * this value to 3 to free one buffer for channel 3 and one for channel 7 */
+ * this value to 3 to free one buffer for channel 3 and one for channel 7.
+ * 
+ * @note Currently used: 0-2 & 4-6 for IR; 3 for HID output; 7 for Neopixels */
 #define HAL_IO_IR_MEM_BLOCKS    3
 
 /** @brief LED update queue

--- a/main/hal/hal_io.h
+++ b/main/hal/hal_io.h
@@ -209,13 +209,7 @@
  * both channels (RX&TX) could use up to 4 blocks for saving waveforms.
  * If there is need for a RMT channel for different purposes (e.g. Neopixel output), reduce
  * this value to 3 to free one buffer for channel 3 and one for channel 7 */
-#define HAL_IO_IR_MEM_BLOCKS    4
-
-//we need an additional RMT block for Neopixel output (if activated)
-#ifdef LED_USE_NEOPIXEL
-  #undef HAL_IO_IR_MEM_BLOCKS
-  #define HAL_IO_IR_MEM_BLOCKS 3
-#endif
+#define HAL_IO_IR_MEM_BLOCKS    3
 
 /** @brief LED update queue
  * 

--- a/main/hal/hal_serial.c
+++ b/main/hal/hal_serial.c
@@ -25,30 +25,22 @@
  * 
  * Attention: this module does NOT use UART0 (terminal & program interface)
  * 
- * The hardware abstraction takes care of: <br>
- * -) sending USB-HID commands <br>
- * -) sending USB-serial responses <br>
- * -) sending/receiving serial data (to/from USB-serial) <br>
+ * The hardware abstraction takes care of:
+ * * sending USB-HID commands
+ * * sending USB-serial responses
+ * * sending/receiving serial data (to/from USB-serial)
  * 
- * The interaction to other parts of the firmware consists of:<br>
- * -) pending on queues for USB commands:<br>
- *    * keyboard_usb_press<br>
- *    * keyboard_usb_release<br>
- *    * mouse_movement_usb<br>
- *    * joystick_movement_usb<br>
- * -) halSerialSendUSBSerial / halSerialReceiveUSBSerial for direct sending/receiving<br>
+ * The interaction to other parts of the firmware consists of:
+ * * pending on queue for USB commands: hid_usb
+ * * halSerialSendUSBSerial / halSerialReceiveUSBSerial for direct sending/receiving (USB-CDC)
  * 
  * The received serial data can be used by different modules, currently
- * the task_commands_cim is used to fetch & parse serial data.
+ * the task_commands is used to fetch & parse serial data.
  * 
- * @todo Reducing stack size by peeking incoming queue for length, give it back and allocate in task_commands.c accordingly
- * 
- * @note In this firmware, there are 3 pins routed to the USB support chip (RX,TX,signal).
- * Depending on the level of the signal line, data sent to the USB chip is either
- * interpreted as USB-HID commands (keyboard, mouse or joystick reports) or
- * the data is forwarded to the USB-CDC interface, which is used to send data 
- * to the host (config GUI, terminal, AsTeRICS,...).
- * 
+ * @note In this firmware, there are 3 pins routed to the USB support chip (RX,TX,HID).
+ * RX/TX lines are used as normal UART, which is converted by the LPC USB chip to 
+ * the USB-CDC interface. The third line (HID) is used as a pulse length modulated output
+ * for transmitting HID commands to the host.
  */ 
  
  
@@ -95,8 +87,6 @@ serialoutput_h outputcb = NULL;
 static const int CMDQUEUE_SIZE = 256;
 
 static const int BUF_SIZE_TX = 512;
-static uint8_t keycode_modifier;
-static uint8_t keycode_arr[8] = {'K',0,0,0,0,0,0,0};
 
 /** @brief Mutex for sending to serial port.
  * */
@@ -254,174 +244,31 @@ void halSerialRXTask(void *pvParameters)
   vTaskDelete(NULL);
 }
 
-void halSerialTaskKeyboardPress(void *param)
-{
-  uint16_t rxK = 0;
-  uint8_t keycode;
-  uint8_t modifier;
-    
-  while(1)
-  {
-    //check if queue is created
-    if(keyboard_usb_press != 0)
-    {
-      //pend on MQ, if timeout triggers, just wait again.
-      if(xQueueReceive(keyboard_usb_press,&rxK,300))
-      {
-        //data here, split into modifier & keycode
-        keycode = rxK & 0x00FF;
-        modifier = (rxK & 0xFF00)>>8;
-        
-        //add modifier to global mask
-        keycode_modifier |= modifier;
-        
-        //keycodes, add directly to the keycode array
-        switch(add_keycode(keycode,&(keycode_arr[2])))
-        {
-          case 0:
-            keycode_arr[0] = 'K';
-            keycode_arr[1] = keycode_modifier;
-            uint8_t sent = 0;
-            for(uint8_t i = 0; i<8; i++) { sent+= halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&keycode_arr[i], 1, 30); }
-            if(sent != 8) ESP_LOGE(LOG_TAG,"Error sending keyboard HID report");
-              
-            ESP_LOGD(LOG_TAG,"HID report (on press):");
-            esp_log_buffer_hex(LOG_TAG,keycode_arr,8);
-            break;
-          case 1: ESP_LOGW(LOG_TAG,"keycode already in queue"); break;
-          case 2: ESP_LOGE(LOG_TAG,"no space in keycode arr!"); break;
-          default: ESP_LOGE(LOG_TAG,"add_keycode return unknown code..."); break;
-        }
-        
-        modifier = 0;
-        keycode = 0;
-        rxK = 0;
-      }
-    } else {
-      ESP_LOGE(LOG_TAG,"keyboard_usb_press queue not initialized, retry in 1s");
-      vTaskDelay(1000/portTICK_PERIOD_MS);
-    }
-  }
-}
-
-void halSerialTaskKeyboardRelease(void *param)
-{
-  uint16_t rxK = 0;
-  uint8_t keycode;
-  uint8_t modifier;
-    
-  while(1)
-  {
-    //check if queue is created
-    if(keyboard_usb_release != 0)
-    {
-      //pend on MQ, if timeout triggers, just wait again.
-      if(xQueueReceive(keyboard_usb_release,&rxK,300))
-      {
-        //data here, split into modifier & keycode
-        keycode = rxK & 0x00FF;
-        modifier = (rxK & 0xFF00)>>8;
-        
-        //remove modifier from global mask
-        keycode_modifier &= ~modifier;
-        
-        //keycodes, remove directly from the keycode array
-        switch(remove_keycode(keycode,&(keycode_arr[2])))
-        {
-          case 0:
-            keycode_arr[0] = 'K';
-            //use global modifier but mask out this released modifier...
-            keycode_arr[1] = keycode_modifier;
-            uint8_t sent = 0;
-            for(uint8_t i = 0; i<8; i++) { sent+= halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&keycode_arr[i], 1, 30); }
-            if(sent != 8) ESP_LOGE(LOG_TAG,"Error sending keyboard HID report");
-            ESP_LOGD(LOG_TAG,"HID report (on release):");
-            esp_log_buffer_hex(LOG_TAG,keycode_arr,8);
-            break;
-          case 1: ESP_LOGW(LOG_TAG,"keycode not in queue"); break;
-          default: ESP_LOGE(LOG_TAG,"remove_keycode return unknown code..."); break;
-        }
-        
-        modifier = 0;
-        keycode = 0;
-        rxK = 0;
-      }
-    } else {
-      ESP_LOGE(LOG_TAG,"keyboard_usb_release queue not initialized, retry in 1s");
-      vTaskDelay(1000/portTICK_PERIOD_MS);
-    }
-  }
-}
-
-void halSerialTaskMouse(void *param)
-{
-  mouse_command_t rxM;
-  static uint8_t emptySent = 0;
-  mouse_command_t emptyReport = {0,0,0,0};
-  memset(&emptyReport,0,sizeof(mouse_command_t));
-  
-  while(1)
-  {
-    //check if queue is created
-    if(mouse_movement_usb != 0)
-    {
-      //pend on MQ, if timeout triggers, just wait again.
-      if(xQueueReceive(mouse_movement_usb,&rxM,300))
-      {
-        //send report always if not empty
-        if(memcmp(&rxM,&emptyReport,sizeof(mouse_command_t)) != 0)
-        {
-          uint8_t sent = 0;
-          char m = 'M';
-          sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,&m,1,30); 
-          sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&rxM.buttons,1,30); 
-          sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&rxM.x,1,30); 
-          sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&rxM.y,1,30); 
-          sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&rxM.wheel,1,30); 
-          
-          if(sent != 5)
-          {
-            ESP_LOGE(LOG_TAG,"Error sending report:");
-          }
-          ESP_LOGD(LOG_TAG,"Mouse: %d,%d,%d,%d",rxM.buttons, \
-              rxM.x, rxM.y, rxM.wheel);
-          //after one non-empty report, we can resend an empty one
-          emptySent = 0;
-          //delay for 1 tick, allowing the USB chip to parse the cmd
-          vTaskDelay(2);
-        } else {
-          //if empty, check if it was sent once, if not: send empty
-          if(emptySent == 0)
-          {
-            uint8_t sent = 0;
-            char m = 'M';
-            sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,&m,1,30); 
-            sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&rxM.buttons,1,30); 
-            sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&rxM.x,1,30); 
-            sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&rxM.y,1,30); 
-            sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&rxM.wheel,1,30); 
-            
-            if(sent != 5)
-            {
-              ESP_LOGE(LOG_TAG,"Error sending report:");
-            }
-
-            ESP_LOGD(LOG_TAG,"Mouse: %d,%d,%d,%d",rxM.buttons, \
-                rxM.x, rxM.y, rxM.wheel);
-            //remember we sent an empty report
-            emptySent = 1;
-            //delay for 1 tick, allowing the USB chip to parse the cmd
-            vTaskDelay(1);
-          }
-        }
-      }
-    } else {
-      ESP_LOGE(LOG_TAG,"mouse_movement_usb queue not initialized, retry in 1s");
-      vTaskDelay(1000/portTICK_PERIOD_MS);
-    }
-  }
-}
-
+/** @brief CONTINOUS TASK - Process HID commands & send via HID wire to LPC
+ * 
+ * This task is used to receive a byte buffer, which contains a HID command
+ * for the LPC. These bytes are converted into either long or short pulses
+ * for 0 and 1 bits, finished by a "very long" stop bit.
+ * 
+ * HID commands are built up following this declarations:
+ * Byte 0: type of command: K/M/J/C:
+ * * K are keyboard reports
+ * * M are mouse reports
+ * * J are joystick reports
+ * * C are set locale commands
+ * 
+ * Following parameter lenghts are valid:
+ * "K": 7 Bytes; 1 modifier + 6 keycode
+ * "M": 4 Bytes; Button mask + X + Y + wheel
+ * "J": 13 Bytes; Please consult task_joystick.c for a detailed explanation
+ * "C": 1 Byte; Locale code, according to HID specification chapter 6.2.1
+ * 
+ * 
+ * @param param Unused
+ * @see usb_command_t
+ * @see hid_usb
+ * @see HAL_SERIAL_HIDPIN
+ * */
 void halSerialHIDTask(void *param)
 {
   usb_command_t rx; //TODO: use right var type
@@ -429,13 +276,10 @@ void halSerialHIDTask(void *param)
   rmt_item32_t rmtBuf[64];
   uint8_t rmtCount = 0;
   
-  //start bit
+  //levels are always same, set here.
   rmt_item32_t item;
-  item.duration0 = HAL_SERIAL_HID_DURATION_0;
-  item.level0 = 0;
-  item.duration1 = HAL_SERIAL_HID_DURATION_S;
-  item.level1 = 1;
-  rmtBuf[0] = item;
+  item.level0 = 1;
+  item.level1 = 0;
   
   while(1)
   {
@@ -445,6 +289,24 @@ void halSerialHIDTask(void *param)
       //pend on MQ, if timeout triggers, just wait again.
       if(xQueueReceive(hid_usb,&rx,portMAX_DELAY))
       {
+        //reset RMT offset
+        rmtCount = 0;
+        
+        //debug output
+        switch(rx.data[0])
+        {
+          case 'M': ESP_LOGI(LOG_TAG,"USB Mouse: B: %d, X/Y: %d/%d, wheel: %d", \
+            rx.data[1],rx.data[2],rx.data[3],rx.data[4]);
+            break;
+          case 'K': ESP_LOGI(LOG_TAG,"USB Kbd: Mod: %d, keys: %d/%d/%d/%d/%d/%d", \
+            rx.data[1],rx.data[2],rx.data[3],rx.data[4],rx.data[5],rx.data[6],rx.data[7]);
+            break;
+          case 'J': ESP_LOGI(LOG_TAG,"USB joystick:");
+            ESP_LOG_BUFFER_HEXDUMP(LOG_TAG,&rx.data[1], 12 ,ESP_LOG_INFO);
+            break;
+          default: ESP_LOGW(LOG_TAG,"Unknown USB report");
+        }
+        
         //build RMT buffer
         for(uint8_t i = 0; i<16; i++)
         {
@@ -457,9 +319,9 @@ void halSerialHIDTask(void *param)
             //process even bit
             if((rx.data[i] & (1<<(j*2))) != 0)
             {
-              item.duration0 = HAL_SERIAL_HID_DURATION_1;
+              item.duration0 = HAL_SERIAL_HID_DURATION_1; //long timing
             } else {
-              item.duration0 = HAL_SERIAL_HID_DURATION_0;
+              item.duration0 = HAL_SERIAL_HID_DURATION_0; //short timing
             }
             //process odd bit
             if((rx.data[i] & (1<<(j*2+1))) != 0)
@@ -469,17 +331,27 @@ void halSerialHIDTask(void *param)
               item.duration1 = HAL_SERIAL_HID_DURATION_0;
             }
             //fill buffer 
-            rmtCount = ((i*8+j*2)/2) + 1;
+            //rmtCount = ((i*8+j*2)/2) + 1;
             rmtBuf[rmtCount] = item;
+            rmtCount++;
           }
         }
+        
+        //signal the RMT the end of this transmission
+        item.duration0 = HAL_SERIAL_HID_DURATION_S; //stop bit timing
+        item.duration1 = 0;
+        rmtBuf[rmtCount] = item;
+        rmtCount++;
+        
+        ESP_LOGV(LOG_TAG,"RMT dump:");
+        ESP_LOG_BUFFER_HEXDUMP(LOG_TAG,rmtBuf, sizeof(rmt_item32_t)*(rmtCount),ESP_LOG_VERBOSE);
     
         //take semaphore
         if(xSemaphoreTake(hidsendingsem,1000/portTICK_PERIOD_MS))
         {
           //put data into RMT buffer
           if(rmt_fill_tx_items(HAL_SERIAL_HID_CHANNEL, rmtBuf, \
-            rmtCount+1, 0) != ESP_OK)
+            rmtCount, 0) != ESP_OK)
           {
             ESP_LOGE(LOG_TAG,"Cannot send data to RMT");
           }
@@ -498,100 +370,6 @@ void halSerialHIDTask(void *param)
     }
   }
 }
-
-void halSerialTaskJoystick(void *param)
-{
-  joystick_command_t rxJ;
-  uint8_t report[13];
-  
-  while(1)
-  {
-    //check if queue is created
-    if(joystick_movement_usb != 0)
-    {
-      //pend on MQ, if timeout triggers, just wait again.
-      if(xQueueReceive(joystick_movement_usb,&rxJ,300))
-      {
-        //limit values
-        if(rxJ.Xaxis > 1023) rxJ.Xaxis = 1023;
-        if(rxJ.Yaxis > 1023) rxJ.Yaxis = 1023;
-        if(rxJ.Zaxis > 1023) rxJ.Zaxis = 1023;
-        if(rxJ.Zrotate > 1023) rxJ.Zrotate = 1023;
-        if(rxJ.sliderLeft > 1023) rxJ.sliderLeft = 1023;
-        if(rxJ.sliderRight > 1023) rxJ.sliderRight = 1023;
-        
-        /*++++ build report ++++*/
-        
-        //13 bytes:
-        //'J'                                     0
-        //buttonmask                              1
-        //buttonmask                              2
-        //buttonmask                              3
-        //buttonmask                              4
-        
-        //hat [b0-b3]. Xaxis [b4-b7]              5
-        //Xaxis [b0-b5], Yaxis[b6-b7]             6
-        //Yaxis [b0-b7]                           7
-        //Zaxis [b0-b7]                           8
-        
-        //Zaxis [b0-b1], zrotate [b2-b7]          9
-        //zrotate[b0-b3],sliderleft[b4-b7]        10
-        //sliderLeft[b0-b5],sliderRight[b6-b7]    11
-        //sliderRight                             12
-        
-        report[0] = 'J';
-        
-        //button mask
-        report[1] = rxJ.buttonmask & 0x000000FF;
-        report[2] = (rxJ.buttonmask & 0x0000FF00) >> 8;
-        report[3] = (rxJ.buttonmask & 0x00FF0000) >> 16;
-        report[4] = (rxJ.buttonmask & 0xFF000000) >> 24;
-        
-        //map hat to 4bits
-        if (rxJ.hat < 0) report[5] = 15;
-        else if (rxJ.hat < 23) report[5] = 0;
-        else if (rxJ.hat < 68) report[5] = 1;
-        else if (rxJ.hat < 113) report[5] = 2;
-        else if (rxJ.hat < 158) report[5] = 3;
-        else if (rxJ.hat < 203) report[5] = 4;
-        else if (rxJ.hat < 245) report[5] = 5;
-        else if (rxJ.hat < 293) report[5] = 6;
-        else if (rxJ.hat < 338) report[5] = 7;
-        //add Xaxis
-        report[5] |= (rxJ.Xaxis & 0x000F) << 4;
-        report[6] =  (rxJ.Xaxis & 0x03F0) >> 4;
-        //add Yaxis
-        report[6] |= (rxJ.Yaxis & 0x0003) << 6;
-        report[7] =  (rxJ.Yaxis & 0x03FC) >> 2;
-        //add Zaxis
-        report[8] = rxJ.Zaxis & 0x00FF;
-        report[9] = (rxJ.Zaxis & 0x0300) >> 8;
-        //add zrotate
-        report[9] |= (rxJ.Zrotate & 0x003F) << 2;
-        report[10] = (rxJ.Zrotate & 0x03C0) >> 6;
-        //add sliderLeft
-        report[10] |= (rxJ.sliderLeft & 0x000F) << 4;
-        report[11] = (rxJ.sliderLeft & 0x03F0) >> 4;
-        //add sliderRight
-        report[11] |= rxJ.sliderRight & 0x0003 << 6;
-        report[12] = (rxJ.sliderRight & 0x03FC) >> 2;
-        
-        //log buffer
-        ESP_LOGD(LOG_TAG,"HID joystick report:");
-        esp_log_buffer_hex(LOG_TAG,report,13);
-        
-        //send it to serial port
-        uint8_t sent = 0;
-        for(uint8_t i = 0; i<13; i++) { sent+= halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&report[i], 1, 30); }
-        if(sent != 13) ESP_LOGE(LOG_TAG,"Error sending joystick HID report");
-      }
-    } else {
-      ESP_LOGE(LOG_TAG,"joystick_movement_usb queue not initialized, retry in 1s");
-      vTaskDelay(1000/portTICK_PERIOD_MS);
-    }
-  }
-}
-
 
 /** @brief Read parsed AT commands from USB-Serial (USB-CDC)
  * 
@@ -630,21 +408,14 @@ int halSerialReceiveUSBSerial(uint8_t **data)
 
 /** @brief Send serial bytes to USB-Serial (USB-CDC)
  * 
- * This method sends bytes to the UART.
- * In addition, the GPIO signal pin is set to route this data
- * to the USB Serial instead of USB-HID.
- * After finishing this transmission, the GPIO is set back to USB-HID
+ * This method sends bytes to the UART, for USB-CDC
  * 
  * @return -1 on error, number of read bytes otherwise
  * @param data Data to be sent
- * @param channel Determines the channel to send this data to (either CDC or HID parser)
  * @param length Number of maximum bytes to send
  * @param ticks_to_wait Maximum time to wait for a free UART
- * 
- * @see HAL_SERIAL_TX_TO_HID
- * @see HAL_SERIAL_TX_TO_CDC
  * */
-int halSerialSendUSBSerial(uint8_t channel, char *data, uint32_t length, TickType_t ticks_to_wait) 
+int halSerialSendUSBSerial(char *data, uint32_t length, TickType_t ticks_to_wait) 
 {
   //check if sem is already initialized
   if(serialsendingsem == NULL)
@@ -655,7 +426,7 @@ int halSerialSendUSBSerial(uint8_t channel, char *data, uint32_t length, TickTyp
   
   //if an additional stream is registered, send data there as well
   //no HID commands will be sent there.
-  if(outputcb != NULL && channel != HAL_SERIAL_TX_TO_HID)
+  if(outputcb != NULL)
   {
     if(outputcb(data,length) != ESP_OK)
     {
@@ -666,21 +437,9 @@ int halSerialSendUSBSerial(uint8_t channel, char *data, uint32_t length, TickTyp
   //acquire mutex to have TX permission on UART
   if(xSemaphoreTake(serialsendingsem, ticks_to_wait) == pdTRUE)
   {
-    //try to switch to USB-Serial
-    if(halSerialSwitchTXChannel(channel,ticks_to_wait)!=ESP_OK)
-    {
-      ESP_LOGE(LOG_TAG,"switch GPIO channel didn't finish");
-      xSemaphoreGive(serialsendingsem);
-      return -1;
-    }
     //send the data
     int txBytes = uart_write_bytes(HAL_SERIAL_UART, data, length);
-    
-    ///@todo AT SR + viele HID commands -> fehlende Zeilenumbrüche, besser so?
-    //if(channel == HAL_SERIAL_TX_TO_CDC) {
-      uart_write_bytes(HAL_SERIAL_UART, "\n", 1);
-    //}
-    
+    uart_write_bytes(HAL_SERIAL_UART, "\n", 1);
     //release mutex
     xSemaphoreGive(serialsendingsem);
     
@@ -703,46 +462,41 @@ int halSerialSendUSBSerial(uint8_t channel, char *data, uint32_t length, TickTyp
  * */
 void halSerialReset(uint8_t exceptDevice)
 {
-  ESP_LOGD(LOG_TAG,"BLE reset reports, except mask: %d",exceptDevice);
+  ESP_LOGD(LOG_TAG,"USB-HID reset reports, except mask: %d",exceptDevice);
   //reset mouse
   if(!(exceptDevice & (1<<2))) 
   {
-    uint8_t sent = 0;
-    char m = 'M';
-    uint8_t zero = 0;
-    int8_t zeroint = 0;
-    sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,&m,1,30); 
-    sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&zero,1,30); 
-    sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&zeroint,1,30); 
-    sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&zeroint,1,30); 
-    sent += halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)&zeroint,1,30); 
+    usb_command_t m;
+    m.len = 5;
+    m.data[0] = 'M';
+    m.data[1] = 0; //buttons
+    m.data[2] = 0; //X
+    m.data[3] = 0; //Y
+    m.data[4] = 0; //wheel
     
-    if(sent != 5)
-    {
-      ESP_LOGE(LOG_TAG,"Error resetting mouse HID report");
-    }
+    //send to queue
+    xQueueSend(hid_usb, &m, 0);
   }
   //reset keyboard
   if(!(exceptDevice & (1<<0)))
   {
-    for(uint8_t i=0;i<8;i++) keycode_arr[i] = 0;
-    keycode_modifier = 0;
-    keycode_arr[0] = 'K';
-    if(halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)keycode_arr, 8, 30) != 8)
-    {
-      ESP_LOGE(LOG_TAG,"Error resetting keyboard HID report");
-    }
+    usb_command_t k;
+    for(uint8_t i=1;i<=8;i++) k.data[i] = 0;
+    k.data[0] = 'K';
+    k.len = 9;
+    //send to queue
+    xQueueSend(hid_usb, &k, 0);
   }
   //reset joystick
   if(!(exceptDevice & (1<<1)))
   {
-    uint8_t report[13];
-    for(uint8_t i=0;i<13;i++) report[i] = 0;
-    report[0] = 'J';
-    if(halSerialSendUSBSerial(HAL_SERIAL_TX_TO_HID,(char *)report, 13, 50) != 13)
-    {
-      ESP_LOGE(LOG_TAG,"Error resetting joystick HID report");
-    }
+    usb_command_t j;
+    for(uint8_t i=1;i<=12;i++) j.data[i] = 0;
+    j.data[0] = 'J';
+    j.len = 13;
+    
+    //send to queue
+    xQueueSend(hid_usb, &j, 0);
   }
 }
 
@@ -845,7 +599,7 @@ esp_err_t halSerialInit(void)
   
   hidoutput_rmt.rmt_mode = RMT_MODE_TX;  //TX mode
   hidoutput_rmt.channel = HAL_SERIAL_HID_CHANNEL; //use define RMT channel
-  hidoutput_rmt.clk_div = 1; //do not divide 80MHz clock; we need to be fast...
+  hidoutput_rmt.clk_div = 10; //do not divide 80MHz clock; we need to be fast...
   hidoutput_rmt.gpio_num = HAL_SERIAL_HIDPIN; //output pin
   hidoutput_rmt.mem_block_num = 1;
   hidoutput_rmt.tx_config.loop_en = 0;     //do not loop
@@ -873,12 +627,8 @@ esp_err_t halSerialInit(void)
    * queue richtig initialisieren (main) */
   
   /*++++ task setup ++++*/
-  
-  //install serial tasks (4x -> keyboard press/release; mouse; joystick)
-  xTaskCreate(halSerialTaskKeyboardPress, "serialKbdPress", HAL_SERIAL_TASK_STACKSIZE, NULL, configMAX_PRIORITIES-3, NULL);
-  xTaskCreate(halSerialTaskKeyboardRelease, "serialKbdRelease", HAL_SERIAL_TASK_STACKSIZE, NULL, configMAX_PRIORITIES-3, NULL);
-  xTaskCreate(halSerialTaskMouse, "serialMouse", HAL_SERIAL_TASK_STACKSIZE, NULL, configMAX_PRIORITIES-3, NULL);
-  xTaskCreate(halSerialTaskJoystick, "serialJoystick", HAL_SERIAL_TASK_STACKSIZE, NULL, configMAX_PRIORITIES-3, NULL);
+  //task for sending HID commands via RMT
+  xTaskCreate(halSerialHIDTask, "serialHID", HAL_SERIAL_TASK_STACKSIZE, NULL, configMAX_PRIORITIES-3, NULL);
   
   //Create a task to handler UART event from ISR
   xTaskCreate(halSerialRXTask, "serialRX", HAL_SERIAL_TASK_STACKSIZE, NULL, 5, NULL);

--- a/main/hal/hal_serial.h
+++ b/main/hal/hal_serial.h
@@ -66,7 +66,7 @@
 
 #define HAL_SERIAL_TXPIN      (GPIO_NUM_17)
 #define HAL_SERIAL_RXPIN      (GPIO_NUM_16)
-#define HAL_SERIAL_SWITCHPIN  (GPIO_NUM_18)
+#define HAL_SERIAL_HIDPIN     (GPIO_NUM_18)
 #define HAL_SERIAL_UART       (UART_NUM_2)
 
 #define HAL_SERIAL_TX_TO_HID  0
@@ -75,6 +75,16 @@
 /**@brief Sets line ending character
  * According to FLipMouse GUI PortIO.cs, \r is used */
 #define HAL_SERIAL_LINE_ENDING '\r'
+
+/** @brief Set RMT channel for HID output */
+#define HAL_SERIAL_HID_CHANNEL RMT_CHANNEL_3
+
+/** @brief Duration of a 0 bit for HID output */
+#define HAL_SERIAL_HID_DURATION_0   4
+/** @brief Duration of a 1 bit for HID output */
+#define HAL_SERIAL_HID_DURATION_1   8
+/** @brief Duration of a start/stop bit for HID output */
+#define HAL_SERIAL_HID_DURATION_S   16
 
 /** @brief Queue for parsed AT commands
  * 

--- a/main/hal/hal_storage.h
+++ b/main/hal/hal_storage.h
@@ -66,6 +66,8 @@
  * @warning Adjust the esp-idf (via "make menuconfig") to use 512B sectors
  * and mode <b>safety</b>!
  * 
+ * @todo Put delete/save to a task, takes very long time...
+ * 
  * @see generalConfig_t
  */
 

--- a/main/helper/keyboard.c
+++ b/main/helper/keyboard.c
@@ -2007,7 +2007,7 @@ uint16_t deadkey_to_keycode(uint16_t keycode, uint8_t locale)
  **/
 uint8_t keycode_to_key(uint16_t keycode)
 {
-	uint8_t key = keycode & 0x3F;
+	uint8_t key = keycode & 0xFF;
 	if (key == KEY_NON_US_100) key = 100;
 	return key;
 }


### PR DESCRIPTION
This branch changes the way of communication between ESP32 and LPC USB chip.
Instead of using the UART + a separated line to signal if it is HID or CDC, now the UART is used for CDC only and the RMT engine is used to transfer a pulse width modulated signal with the HID commands to the LPC chip.

Advantages:
- Saving ~6kB of task stack sizes, because there is only one task now
- More bandwidth, no interfering if much CDC and HID data is sent
- Much more stable